### PR TITLE
Use WebView.evaluateJavascript() for KitKat and higher

### DIFF
--- a/compiler/src/main/java/com/flipboard/goldengate/BridgeInterface.java
+++ b/compiler/src/main/java/com/flipboard/goldengate/BridgeInterface.java
@@ -1,8 +1,11 @@
 package com.flipboard.goldengate;
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.webkit.WebView;
 
 import com.google.gson.reflect.TypeToken;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -121,13 +124,26 @@ public class BridgeInterface {
                     .addStatement("this.$N = new ResultBridge()", "resultBridge")
                     .addStatement("this.$N = new $T()", "receiverIds", AtomicLong.class)
                     .addStatement("this.$N.addJavascriptInterface($N, $L)", "webView", "resultBridge", "\"" + name + "\"")
-                    .addCode("webView.loadUrl(\"javascript:\" +\n" +
+                    .addCode("evaluateJavascript(\n" +
                             "                \"function GoldenGate$$$$CreateCallback(receiver) {\" +\n" +
                             "                \"    return function(result) {\" +\n" +
                             "                \"        $N.onResult(JSON.stringify({receiver: receiver, result: JSON.stringify(result)}))\" +\n" +
                             "                \"    }\" +\n" +
                             "                \"}\");", name)
                     .build()
+        );
+
+        bridge.addMethod(
+                MethodSpec.methodBuilder("evaluateJavascript")
+                        .addModifiers(Modifier.PRIVATE)
+                        .addAnnotation(AnnotationSpec.builder(TargetApi.class).addMember("value", "$T.VERSION_CODES.KITKAT", Build.class).build())
+                        .addParameter(String.class, "javascript")
+                        .beginControlFlow("if ($T.VERSION.SDK_INT >= $T.VERSION_CODES.KITKAT)", Build.class, Build.class)
+                        .addStatement("this.$N.evaluateJavascript($N, null)", "webView", "javascript")
+                        .nextControlFlow("else ")
+                        .addStatement("this.$N.loadUrl(\"javascript:\" + $N)", "webView", "javascript")
+                        .endControlFlow()
+                        .build()
         );
 
         // Add Bridge methods

--- a/compiler/src/main/java/com/flipboard/goldengate/BridgeMethod.java
+++ b/compiler/src/main/java/com/flipboard/goldengate/BridgeMethod.java
@@ -108,7 +108,7 @@ public class BridgeMethod {
                 if (bridge.isDebug) {
                     codeBlock.addStatement("android.util.Log.d($S, javascript)", bridge.name);
                 }
-                codeBlock.addStatement("this.webView.loadUrl(\"javascript:\" + javascript)");
+                codeBlock.addStatement("evaluateJavascript(javascript)");
                 methodSpec.addCode(codeBlock.build());
             } else {
                 CodeBlock.Builder codeBlock = CodeBlock.builder();
@@ -116,7 +116,7 @@ public class BridgeMethod {
                 if (bridge.isDebug) {
                     codeBlock.addStatement("android.util.Log.d($S, javascript)", bridge.name);
                 }
-                codeBlock.addStatement("this.webView.loadUrl(\"javascript:\" + javascript)");
+                codeBlock.addStatement("evaluateJavascript(javascript)");
                 methodSpec.addCode(codeBlock.build());
             }
         } else {
@@ -126,7 +126,7 @@ public class BridgeMethod {
                 if (bridge.isDebug) {
                     codeBlock.addStatement("android.util.Log.d($S, javascript)", bridge.name);
                 }
-                codeBlock.addStatement("this.webView.loadUrl(\"javascript:\" + javascript)");
+                codeBlock.addStatement("evaluateJavascript(javascript)");
                 methodSpec.addCode(codeBlock.build());
             } else {
                 CodeBlock.Builder codeBlock = CodeBlock.builder();
@@ -134,7 +134,7 @@ public class BridgeMethod {
                 if (bridge.isDebug) {
                     codeBlock.addStatement("android.util.Log.d($S, javascript)", bridge.name);
                 }
-                codeBlock.addStatement("this.webView.loadUrl(\"javascript:\" + javascript)");
+                codeBlock.addStatement("evaluateJavascript(javascript)");
                 methodSpec.addCode(codeBlock.build());
             }
         }

--- a/compiler/src/main/java/com/flipboard/goldengate/BridgeProperty.java
+++ b/compiler/src/main/java/com/flipboard/goldengate/BridgeProperty.java
@@ -55,7 +55,7 @@ public class BridgeProperty {
             if (bridge.isDebug) {
                 codeBlock.addStatement("android.util.Log.d($S, javascript)", bridge.name);
             }
-            codeBlock.addStatement("this.webView.loadUrl(\"javascript:\" + javascript)");
+            codeBlock.addStatement("evaluateJavascript(javascript)");
             methodSpec.addCode(codeBlock.build());
         } else {
             methodSpec.addParameter(TypeName.get(parameter.type), parameter.name, Modifier.FINAL);
@@ -64,7 +64,7 @@ public class BridgeProperty {
             if (bridge.isDebug) {
                 codeBlock.addStatement("android.util.Log.d($S, javascript)", bridge.name);
             }
-            codeBlock.addStatement("this.webView.loadUrl(\"javascript:\" + javascript)");
+            codeBlock.addStatement("evaluateJavascript(javascript)");
             methodSpec.addCode(codeBlock.build());
         }
 


### PR DESCRIPTION
Using `WebView.loadUrl("javascript:...")` works differently when targetting KitKat or newer.
After KitKat, calling `loadUrl()` will evaluate the URL and completely replace the contents of the current page.
To avoid losing JavaScript variable bindings, we should use `WebView.evaluateJavascript()` (added in KitKat).

More Info: https://commonsware.com/blog/2013/10/31/quick-musings-android-4p4.html
